### PR TITLE
Build a static framework

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "mparticle/mparticle-apple-sdk" ~> 7.4.0
+github "mparticle/mparticle-apple-sdk" ~> 7.5.0

--- a/mParticle-Button.podspec
+++ b/mParticle-Button.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = "mParticle-Button"
-    s.version          = "7.4.2"
+    s.version          = "7.5.0"
     s.summary          = "Button integration for mParticle"
 
     s.description      = <<-DESC
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
 
     s.ios.deployment_target = "8.0"
     s.ios.source_files      = 'mParticle-Button/*.{h,m,mm}'
-    s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 7.4.0'
+    s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 7.5.0'
 end

--- a/mParticle-Button.podspec
+++ b/mParticle-Button.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = "mParticle-Button"
-    s.version          = "7.5.0"
+    s.version          = "7.5.1"
     s.summary          = "Button integration for mParticle"
 
     s.description      = <<-DESC

--- a/mParticle-Button.xcodeproj/project.pbxproj
+++ b/mParticle-Button.xcodeproj/project.pbxproj
@@ -216,6 +216,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mparticle.mParticle-Button";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -352,6 +353,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mparticle.mParticle-Button";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -374,6 +376,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mparticle.mParticle-Button";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
Change Mach-o type to static library.
Updates mparticle-apple-sdk dependency to `~>7.5.0`. It shouldn't have any impact. Walmart.app links forked mparticle-apple-sdk which is already at v7.5.1.