### PR TITLE
Remove Carthage dependencies

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,4 @@
-github "mparticle/mparticle-apple-sdk" ~> 7.5.0
+# mparticle-apple-sdk is present in and linked by ios-walmart repo.
+# Carthage dependency isn't required.
+
+# github "mparticle/mparticle-apple-sdk" ~> 7.5.0


### PR DESCRIPTION
I believe checking out dependencies defined in this projects Cartfile is causing issues when fetching dependencies on looper.

```
07:09:19 A shell task (/usr/bin/env git checkout --quiet --force v7.5.4-qadeployment (launched in /Users/jenkinspan/Library/Caches/org.carthage.CarthageKit/dependencies/mparticle-apple-sdk)) failed with exit code 128:
07:09:19 fatal: Unable to create '/Users/jenkinspan/Library/Caches/org.carthage.CarthageKit/dependencies/mparticle-apple-sdk/index.lock': File exists.
07:09:19 
07:09:19 Another git process seems to be running in this repository, e.g.
07:09:19 an editor opened by 'git commit'. Please make sure all processes
07:09:19 are terminated then try again. If it still fails, a git process
07:09:19 may have crashed in this repository earlier:
07:09:19 remove the file manually to continue.
```

These dependencies are not used. mparticle-apple-sdk and other .framework files that mparticle integrations depend on is either linked at our own forks or in the Walmart project in ios-walmart repo.